### PR TITLE
Fix postgres package name in setup script

### DIFF
--- a/postgres_init.sh
+++ b/postgres_init.sh
@@ -1,5 +1,5 @@
 sudo apt update
-sudo apt install postgres
+sudo apt install postgresql
 sudo service postgresql start
 sudo -u postgres psql
 ALTER USER postgres with encrypted password 'postgres';


### PR DESCRIPTION
## Summary
- correct `postgresql` package name in `postgres_init.sh`

## Testing
- `python -m compileall -q app`

## Summary by Sourcery

Bug Fixes:
- Correct the apt install command to use `postgresql` instead of `postgres` in postgres_init.sh